### PR TITLE
Update _wp-classes.scss

### DIFF
--- a/assets/styles/components/_wp-classes.scss
+++ b/assets/styles/components/_wp-classes.scss
@@ -23,7 +23,7 @@ article.sticky{
   // margin-bottom: ($line-height-computed / 2);
   height: auto;
 }
-@media (small) {
+@include breakpoint(small) {
   // Only float if not on an extra small device
   .alignleft {
     float: left;


### PR DESCRIPTION
correct syntax for foundation 6 media query